### PR TITLE
feat(configuration): adds MySQL and SSO to integrate with Open edX to prototype course-based permissions

### DIFF
--- a/README-openedx.md
+++ b/README-openedx.md
@@ -20,3 +20,47 @@ Superset needs to be able to access the Open edX MySQL database. To do this in t
 [install-superset]: https://superset.apache.org/docs/installation/installing-superset-using-docker-compose/
 [upstream-docker-compose-non-dev]: https://github.com/apache/superset/blob/master/docker-compose-non-dev.yml
 [login-superset]: https://superset.apache.org/docs/installation/installing-superset-using-docker-compose#4-log-in-to-superset
+
+## Single Sign-On (SSO)
+
+Configure SSO authentication on Superset to use the OAuth2 application created on Open edX.
+
+**WARNING:** The files and credentials presented here are insecure, and should only be used in a development environment.
+
+### Open edX
+
+1. [Launch an LMS shell][tutor-shell]:
+
+    ```
+    tutor dev run lms bash
+    ```
+1. Add a user for superset's authentication:
+
+    ```
+    ./manage.py lms manage_user superset superset@apache
+    ```
+1. Create a Django OAuth Toolkit › Application with provider name openedxsso:
+
+    ```
+    ./manage.py lms create_dot_application \
+        --grant-type authorization-code \
+        --redirect-uris "http://localhost:8088/oauth-authorized/openedxsso" \
+        --client-id superset-client \
+        --client-secret superset-secret \
+        --scopes user_id \
+        superset-sso superset
+    ```
+
+### Superset
+
+The following files create a custom [Custom OAuth2 Configuration][sso-superset], with a default set of credentials for connecting to Tutor dev.
+
+* [requirements-openedx.txt](docker/requirements-openedx.txt) : installs `authlib `as a python dependency
+* [openedx_sso_security_manager.py](docker/pythonpath_dev/openedx_sso_security_manager.py) : adds a custom authentication manager which fetches the SSO user's details from the Open edX API.
+
+   **TODO:** This manager assumes that all authenticated users are Admin users; this will be changed as this document progresses.
+* [superset_config_tutor_dev.py](docker/pythonpath_dev/superset_config_tutor_dev.py) : adds configuration for SSO OAuth using the OpenEdxSsoSecurityManager, using an insecure set of credentials for connecting to Tutor dev.
+
+
+[tutor-shell]: https://github.com/overhangio/tutor/blob/master/docs/dev.rst#running-arbitrary-commands
+[sso-superset]: https://superset.apache.org/docs/installation/configuring-superset/#custom-oauth2-configuration

--- a/README-openedx.md
+++ b/README-openedx.md
@@ -64,3 +64,23 @@ The following files create a custom [Custom OAuth2 Configuration][sso-superset],
 
 [tutor-shell]: https://github.com/overhangio/tutor/blob/master/docs/dev.rst#running-arbitrary-commands
 [sso-superset]: https://superset.apache.org/docs/installation/configuring-superset/#custom-oauth2-configuration
+
+## Connect Superset to the Open edX MySQL database
+
+[Connecting to a MySQL database][mysql-superset] requires adding a python dependency, which has been added for this fork to
+[requirements-openedx.txt](docker/requirements-openedx.txt).
+
+1. Login to Superset UI via SSO.
+1. Add a [new Data connection][db-superset] using the MySQL connector and the Tutor dev MySQL database credentials.
+
+    For Tutor dev, these are:
+    * Host: `tutor_dev_mysql_1`
+    * Port: `3306`
+    * Database name: `openedx`
+    * Username: `openedx`
+    * Password: use the `OPENEDX_MYSQL_PASSWORD` generated to your `$(tutor config printroot)/config.yml"`
+1. Create a [Dataset and Dashboard][dashboard-superset] as desired.
+
+[mysql-superset]: https://superset.apache.org/docs/databases/mysql
+[db-superset]: https://superset.apache.org/docs/databases/db-connection-ui/
+[dashboard-superset]: https://superset.apache.org/docs/creating-charts-dashboards/creating-your-first-dashboard/

--- a/README-openedx.md
+++ b/README-openedx.md
@@ -9,7 +9,7 @@ Superset needs to be able to access the Open edX MySQL database. To do this in t
 1. Create `docker/pythonpath_dev/superset_config_docker.py`, and add:
 
     ```
-    # Copy the `OPENEDX_MYSQL_PASSWORD` generated to your `$(tutor config printroot)/config.yml"`
+    # Copy the `OPENEDX_MYSQL_PASSWORD` generated to your `$(tutor config printroot)/config.yml`
     OPENEDX_DATABASE_PASSWORD = "<redacted>"
     ```
 1. Start Superset, using [docker-compose-tutor-dev.yml](docker-compose-tutor-dev.yml) (a modified version of
@@ -120,7 +120,7 @@ Steps to follow:
     * Tables: `openedx.student_courseenrollment`
     * Roles: `Open edX`
     * Group Key: `courses`
-    * Clause: `{{can_view_courses()}}`
+    * Clause: `{{can_view_courses(current_username(), 'course_id')}}`
 
 To try this out:
 
@@ -129,14 +129,6 @@ To try this out:
 1. Add various users as staff members to your courses.
 1. Login to Superset as one of those staff members, and view the `Open edX Enrollment` chart created above.
    Note that it shows different course enrollment data depending on who is logged in.
-
-### Know issues
-
-[Superset caches][cache-superset] charts and result sets by default, and these caches don't take into account dynamic row-based permissions. So you have to refresh the cache in order to see different
-data for different users.
-
-This can be fixed with configuration, but might prove a detriment to performance.
-
 
 [roles-superset]: https://superset.apache.org/docs/security/#provided-roles
 [sql-templating-superset]: https://superset.apache.org/docs/installation/sql-templating/#sql-templating

--- a/README-openedx.md
+++ b/README-openedx.md
@@ -6,7 +6,12 @@ Superset needs to be able to access the Open edX MySQL database. To do this in t
 
 1. [Install and run Tutor dev][install-tutor]
 1. [Install Superset locally using Docker Compose][install-superset], using this fork/branch.
+1. Create `docker/pythonpath_dev/superset_config_docker.py`, and add:
 
+    ```
+    # Copy the `OPENEDX_MYSQL_PASSWORD` generated to your `$(tutor config printroot)/config.yml"`
+    OPENEDX_DATABASE_PASSWORD = "<redacted>"
+    ```
 1. Start Superset, using [docker-compose-tutor-dev.yml](docker-compose-tutor-dev.yml) (a modified version of
    [docker-compose-non-dev.yml][upstream-docker-compose-non-dev]) so that it shares Tutor's network:
 
@@ -57,8 +62,6 @@ The following files create a custom [Custom OAuth2 Configuration][sso-superset],
 
 * [requirements-openedx.txt](docker/requirements-openedx.txt) : installs `authlib `as a python dependency
 * [openedx_sso_security_manager.py](docker/pythonpath_dev/openedx_sso_security_manager.py) : adds a custom authentication manager which fetches the SSO user's details from the Open edX API.
-
-   **TODO:** This manager assumes that all authenticated users are Admin users; this will be changed as this document progresses.
 * [superset_config_tutor_dev.py](docker/pythonpath_dev/superset_config_tutor_dev.py) : adds configuration for SSO OAuth using the OpenEdxSsoSecurityManager, using an insecure set of credentials for connecting to Tutor dev.
 
 
@@ -70,7 +73,7 @@ The following files create a custom [Custom OAuth2 Configuration][sso-superset],
 [Connecting to a MySQL database][mysql-superset] requires adding a python dependency, which has been added for this fork to
 [requirements-openedx.txt](docker/requirements-openedx.txt).
 
-1. Login to Superset UI via SSO.
+1. Login to Superset UI via SSO as a LMS superuser.
 1. Add a [new Data connection][db-superset] using the MySQL connector and the Tutor dev MySQL database credentials.
 
     For Tutor dev, these are:
@@ -79,8 +82,65 @@ The following files create a custom [Custom OAuth2 Configuration][sso-superset],
     * Database name: `openedx`
     * Username: `openedx`
     * Password: use the `OPENEDX_MYSQL_PASSWORD` generated to your `$(tutor config printroot)/config.yml"`
-1. Create a [Dataset and Dashboard][dashboard-superset] as desired.
+1. Create a [Dataset][dashboard-superset] using the above data connection on the `openedx` database.
+1. Create a [Chart][chart-superset] using the above data set, and Save:
+    * Title: `Open edX Enrollments`
+    * Chart Source: `openedx.student_courseenrollment`
+    * Metrics: `COUNT(*)`
+    * Data > Time Column: `created`
+    * Data > Time Grain: `Day`
+
 
 [mysql-superset]: https://superset.apache.org/docs/databases/mysql
 [db-superset]: https://superset.apache.org/docs/databases/db-connection-ui/
 [dashboard-superset]: https://superset.apache.org/docs/creating-charts-dashboards/creating-your-first-dashboard/
+[chart-superset]: https://superset.apache.org/docs/miscellaneous/chart-params/#chart-parameters
+
+## Restrict access to Open edX Enrollments to course staff
+
+We can use the following Superset features to enforce a restriction to protect access by course to enrollments data:
+
+* [Built-in roles][roles-superset]
+* [Dataset security][dataset-security-superset] applied to a custom role we will add manually.
+* [SQL Templating][sql-templating-superset], and the `can_view_courses()` custom Jinja template function added by this fork/branch.
+* Superset's [Row Level Security][row-level-security-superset] filters.
+
+Steps to follow:
+
+1. Login to Superset UI via SSO as a LMS superuser.
+1. [Create a new role][gamma-dataset-role-superset] with access to the `openedx` MySQL data set created above.
+    * Name: `Open edX`
+    * Permissions: `schema access on [Open edX MySQL].[openedx]`
+    * User: (leave blank)
+      Users will be automatically assigned to this role when they login via our custom SSO Security Manager.
+1. Create a [Row Level Security][row-level-security-superset] filter:
+    * Name: `Enrollments`
+    * Description: `Restrict access to the Course Enrollments table`
+    * Filter Type: `Regular`
+    * Tables: `openedx.student_courseenrollment`
+    * Roles: `Open edX`
+    * Group Key: `courses`
+    * Clause: `{{can_view_courses()}}`
+
+To try this out:
+
+1. Login to Tutor Studio as a staff or superuser.
+1. Create one or more courses.
+1. Add various users as staff members to your courses.
+1. Login to Superset as one of those staff members, and view the `Open edX Enrollment` chart created above.
+   Note that it shows different course enrollment data depending on who is logged in.
+
+### Know issues
+
+[Superset caches][cache-superset] charts and result sets by default, and these caches don't take into account dynamic row-based permissions. So you have to refresh the cache in order to see different
+data for different users.
+
+This can be fixed with configuration, but might prove a detriment to performance.
+
+
+[roles-superset]: https://superset.apache.org/docs/security/#provided-roles
+[sql-templating-superset]: https://superset.apache.org/docs/installation/sql-templating/#sql-templating
+[gamma-dataset-role-superset]: https://superset.apache.org/docs/security/#managing-data-source-access-for-gamma-roles
+[dataset-security-superset]: https://superset.apache.org/docs/security/#restricting-access-to-a-subset-of-data-sources
+[row-level-security-superset]: https://superset.apache.org/docs/security/#row-level-security
+[cache-superset]: https://superset.apache.org/docs/installation/cache/

--- a/README-openedx.md
+++ b/README-openedx.md
@@ -1,0 +1,22 @@
+# Superset + Open edX
+
+## Stand up Superset in a development environment
+
+Superset needs to be able to access the Open edX MySQL database. To do this in the Tutor dev environment, Superset needs to share the same docker network.
+
+1. [Install and run Tutor dev][install-tutor]
+1. [Install Superset locally using Docker Compose][install-superset], using this fork/branch.
+
+1. Start Superset, using [docker-compose-tutor-dev.yml](docker-compose-tutor-dev.yml) (a modified version of
+   [docker-compose-non-dev.yml][upstream-docker-compose-non-dev]) so that it shares Tutor's network:
+
+    ```
+	# Pull and start the docker containers
+    docker-compose -f docker-compose-tutor-dev.yml pull
+    docker-compose -f docker-compose-tutor-dev.yml up
+    ```
+
+[install-tutor]: https://docs.tutor.overhang.io/install.html#installing-from-source
+[install-superset]: https://superset.apache.org/docs/installation/installing-superset-using-docker-compose/
+[upstream-docker-compose-non-dev]: https://github.com/apache/superset/blob/master/docker-compose-non-dev.yml
+[login-superset]: https://superset.apache.org/docs/installation/installing-superset-using-docker-compose#4-log-in-to-superset

--- a/docker-compose-tutor-dev.yml
+++ b/docker-compose-tutor-dev.yml
@@ -1,0 +1,113 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+x-superset-image: &superset-image apache/superset:${TAG:-latest-dev}
+x-superset-depends-on: &superset-depends-on
+  - db
+  - redis
+x-superset-volumes: &superset-volumes
+  # /app/pythonpath_docker will be appended to the PYTHONPATH in the final container
+  - ./docker:/app/docker
+  - superset_home:/app/superset_home
+
+version: "3.7"
+services:
+  redis:
+    image: redis:latest
+    container_name: superset_cache
+    restart: unless-stopped
+    volumes:
+      - redis:/data
+    networks:
+      - superset
+
+  db:
+    env_file: docker/.env-non-dev
+    image: postgres:10
+    container_name: superset_db
+    restart: unless-stopped
+    volumes:
+      - db_home:/var/lib/postgresql/data
+    networks:
+      - superset
+
+  superset:
+    env_file: docker/.env-non-dev
+    image: *superset-image
+    container_name: superset_app
+    command: ["/app/docker/docker-bootstrap.sh", "app-gunicorn"]
+    user: "root"
+    restart: unless-stopped
+    ports:
+      - 8088:8088
+    depends_on: *superset-depends-on
+    volumes: *superset-volumes
+    networks:
+      - superset
+
+  superset-init:
+    image: *superset-image
+    container_name: superset_init
+    command: ["/app/docker/docker-init.sh"]
+    env_file: docker/.env-non-dev
+    depends_on: *superset-depends-on
+    user: "root"
+    volumes: *superset-volumes
+    healthcheck:
+      disable: true
+    networks:
+      - superset
+
+  superset-worker:
+    image: *superset-image
+    container_name: superset_worker
+    command: ["/app/docker/docker-bootstrap.sh", "worker"]
+    env_file: docker/.env-non-dev
+    restart: unless-stopped
+    depends_on: *superset-depends-on
+    user: "root"
+    volumes: *superset-volumes
+    healthcheck:
+      test: ["CMD-SHELL", "celery inspect ping -A superset.tasks.celery_app:app -d celery@$$HOSTNAME"]
+    networks:
+      - superset
+
+  superset-worker-beat:
+    image: *superset-image
+    container_name: superset_worker_beat
+    command: ["/app/docker/docker-bootstrap.sh", "beat"]
+    env_file: docker/.env-non-dev
+    restart: unless-stopped
+    depends_on: *superset-depends-on
+    user: "root"
+    volumes: *superset-volumes
+    healthcheck:
+      disable: true
+    networks:
+      - superset
+
+volumes:
+  superset_home:
+    external: false
+  db_home:
+    external: false
+  redis:
+    external: false
+
+
+networks:
+  superset:
+    name: tutor_dev_default

--- a/docker/docker-bootstrap.sh
+++ b/docker/docker-bootstrap.sh
@@ -19,6 +19,7 @@
 set -eo pipefail
 
 REQUIREMENTS_LOCAL="/app/docker/requirements-local.txt"
+REQUIREMENTS_OPENEDX="/app/docker/requirements-openedx.txt"
 # If Cypress run – overwrite the password for admin and export env variables
 if [ "$CYPRESS_CONFIG" == "true" ]; then
     export SUPERSET_CONFIG=tests.integration_tests.superset_test_config
@@ -28,6 +29,13 @@ fi
 #
 # Make sure we have dev requirements installed
 #
+if [ -f "${REQUIREMENTS_OPENEDX}" ]; then
+  echo "Installing Open edX overrides at ${REQUIREMENTS_OPENEDX}"
+  pip install -r "${REQUIREMENTS_OPENEDX}"
+else
+  echo "Skipping Open edX overrides"
+fi
+
 if [ -f "${REQUIREMENTS_LOCAL}" ]; then
   echo "Installing local overrides at ${REQUIREMENTS_LOCAL}"
   pip install -r "${REQUIREMENTS_LOCAL}"

--- a/docker/pythonpath_dev/.gitignore
+++ b/docker/pythonpath_dev/.gitignore
@@ -21,3 +21,5 @@
 !.gitignore
 !superset_config.py
 !superset_config_local.example
+!openedx_sso_security_manager.py
+!superset_config_tutor_dev.py

--- a/docker/pythonpath_dev/openedx_sso_security_manager.py
+++ b/docker/pythonpath_dev/openedx_sso_security_manager.py
@@ -1,0 +1,70 @@
+import logging
+from superset.security import SupersetSecurityManager
+from superset.extensions import security_manager
+from superset.utils.core import get_username
+from superset.utils.memoized import memoized
+
+
+class OpenEdxSsoSecurityManager(SupersetSecurityManager):
+
+    def oauth_user_info(self, provider, response=None):
+        logging.debug(f"Oauth2 provider: {provider}, response={response}.")
+        if provider == 'openedxsso':
+            me = self.appbuilder.sm.oauth_remotes[provider].get('api/user/v1/me').json()
+            logging.debug("me: {0}".format(me))
+            username = me['username']
+            user_profile = self.appbuilder.sm.oauth_remotes[provider].get(f"api/user/v1/accounts/{username}").json()
+            logging.debug("user_profile: {0}".format(user_profile))
+
+            return {
+                'name': user_profile['name'],
+                'email': user_profile['email'],
+                'id': user_profile['username'],
+                'username': user_profile['username'],
+                'first_name': '',
+                'last_name': '',
+                # FIXME: need to fetch this from an Open edX API too
+                'role_keys': ["admin"],
+            }
+
+
+def can_view_courses():
+    """
+    Fetch the list of courses for the current user.
+    """
+    username = get_username()
+    courses = _can_view_courses(username)
+    courses_in = "(" + ",".join(courses) + ")"
+    return courses_in
+
+
+@memoized
+def _can_view_courses(username, access="staff", next_url=None):
+    """
+    Returns the list of courses the current user has access to.
+    """
+    # TODO: global staff users have access to all courses, but:
+    # a) we don't have an API that tells us if a user is a global staff/superuser, and
+    # b) we shouldn't ever fetch the full list of courses.
+    #
+    # FIXME: what happens when the list of courses grows beyond what the query will handle?
+    courses = []
+    url = next_url or f"api/courses/v1/courses/?permissions={access}&username={username}"
+
+    # FIXME: fails with "missing token".  bugger.
+    response = security_manager.oauth_remotes["openedxsso"].get(url).json()
+
+    for course in response.get('results', []):
+        course_id = course.get('course_id')
+        if course_id:
+            courses.append(course_id)
+
+    # Recurse to iterate over all the pages of results
+    if response.get("next"):
+        next_courses = _can_view_courses(username, next_url=response['next'])
+        for course_id in next_courses:
+            courses.append(course_id)
+
+    # If you have staff access to one or more courses, you get to be an admin.
+    logging.debug(f"Courses for {username}: {courses}")
+    return courses

--- a/docker/pythonpath_dev/openedx_sso_security_manager.py
+++ b/docker/pythonpath_dev/openedx_sso_security_manager.py
@@ -54,11 +54,15 @@ def get_user_roles(username):
     logging.debug(f"user access: {user_access}")
 
     if user_access.is_superuser:
-        return ["admin", "alpha"]
+        return ["admin", "alpha", "openedx"]
     elif user_access.is_staff:
         return ["alpha", "openedx"]
     else:
-        return ["gamma", "openedx"]
+        # User has to have staff access to one or more courses to view any content here.
+        courses = _get_courses(username)
+        if courses:
+            return ["gamma", "openedx"]
+        return []
 
 
 def can_view_courses(field_name='course_id'):

--- a/docker/pythonpath_dev/superset_config.py
+++ b/docker/pythonpath_dev/superset_config.py
@@ -110,6 +110,20 @@ WEBDRIVER_BASEURL_USER_FRIENDLY = WEBDRIVER_BASEURL
 SQLLAB_CTAS_NO_LIMIT = True
 
 #
+# Optionally import superset_config_tutor_dev.py (which will have been included on
+# the PYTHONPATH) in order to allow for local settings to be overridden
+#
+try:
+    import superset_config_tutor_dev
+    from superset_config_tutor_dev import *  # noqa
+
+    logger.info(
+        f"Loaded your Docker configuration at " f"[{superset_config_tutor_dev.__file__}]"
+    )
+except ImportError:
+    pass
+
+#
 # Optionally import superset_config_docker.py (which will have been included on
 # the PYTHONPATH) in order to allow for local settings to be overridden
 #

--- a/docker/pythonpath_dev/superset_config_tutor_dev.py
+++ b/docker/pythonpath_dev/superset_config_tutor_dev.py
@@ -1,0 +1,58 @@
+from flask_appbuilder.security.manager import AUTH_OAUTH
+
+# Set the authentication type to OAuth
+AUTH_TYPE = AUTH_OAUTH
+
+OAUTH_PROVIDERS = [
+    {   'name':'openedxsso',
+        'token_key':'access_token', # Name of the token in the response of access_token_url
+        'icon':'fa-address-card',   # Icon for the provider
+        'remote_app': {
+            'client_id':'superset-client',  # Client Id (Identify Superset application)
+            'client_secret':'superset-secret', # Secret for this Client Id (Identify Superset application)
+            'client_kwargs':{
+                'scope': 'read'               # Scope for the Authorization
+            },
+            'access_token_method':'POST',    # HTTP Method to call access_token_url
+            'access_token_params':{        # Additional parameters for calls to access_token_url
+                'client_id':'superset-client'
+            },
+            'access_token_headers':{    # Additional headers for calls to access_token_url
+                'Authorization': 'Basic Base64EncodedClientIdAndSecret'
+            },
+            'api_base_url':'http://local.overhang.io:8000',
+            'access_token_url':'http://local.overhang.io:8000/oauth2/access_token/',
+            'authorize_url':'http://local.overhang.io:8000/oauth2/authorize/'
+        }
+    }
+]
+
+# Will allow user self registration, allowing to create Flask users from Authorized User
+AUTH_USER_REGISTRATION = True
+
+# The default user self registration role
+AUTH_USER_REGISTRATION_ROLE = "Public"
+
+# Should we replace ALL the user's roles each login, or only on registration?
+AUTH_ROLES_SYNC_AT_LOGIN = True
+
+# map from the values of `userinfo["role_keys"]` to a list of Superset roles
+AUTH_ROLES_MAPPING = {
+    "user": ["User"],
+    "admin": ["Admin"],
+}
+
+from openedx_sso_security_manager import OpenEdxSsoSecurityManager, can_view_courses
+CUSTOM_SECURITY_MANAGER = OpenEdxSsoSecurityManager
+
+
+# Enable use of variables in datasets/queries
+FEATURE_FLAGS = {
+    "ALERT_REPORTS": True,
+    "ENABLE_TEMPLATE_PROCESSING": True,
+}
+
+# Add this custom template processor which returns the list of courses the current user can access
+JINJA_CONTEXT_ADDONS = {
+    'can_view_courses': can_view_courses
+}

--- a/docker/pythonpath_dev/superset_config_tutor_dev.py
+++ b/docker/pythonpath_dev/superset_config_tutor_dev.py
@@ -31,15 +31,19 @@ OAUTH_PROVIDERS = [
 AUTH_USER_REGISTRATION = True
 
 # The default user self registration role
-AUTH_USER_REGISTRATION_ROLE = "Public"
+AUTH_USER_REGISTRATION_ROLE = "Gamma"
 
 # Should we replace ALL the user's roles each login, or only on registration?
 AUTH_ROLES_SYNC_AT_LOGIN = True
 
 # map from the values of `userinfo["role_keys"]` to a list of Superset roles
+# cf https://superset.apache.org/docs/security/#roles
 AUTH_ROLES_MAPPING = {
-    "user": ["User"],
-    "admin": ["Admin"],
+    "admin": ["Admin"],      # Superusers
+    "alpha": ["Alpha"],      # Global staff
+    "gamma": ["Gamma"],      # Course staff
+    "openedx": ["Open edX"], # Open edX datastore, manually created
+    "public": ["Public"],    # AKA anonymous users
 }
 
 from openedx_sso_security_manager import OpenEdxSsoSecurityManager, can_view_courses

--- a/docker/requirements-openedx.txt
+++ b/docker/requirements-openedx.txt
@@ -1,0 +1,1 @@
+authlib  # OAuth2

--- a/docker/requirements-openedx.txt
+++ b/docker/requirements-openedx.txt
@@ -1,1 +1,2 @@
 authlib  # OAuth2
+mysqlclient


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Proof of concept to test whether Superset can be configured to restrict access to data by course membership.

See https://github.com/openedx/data-wg/issues/21

### TESTING INSTRUCTIONS

See added [README-openedx.md](https://github.com/open-craft/superset/blob/jill/openedx-sso/README-openedx.md) for full instructions.